### PR TITLE
Fix syntax error in call to action component

### DIFF
--- a/src/components/common/CallToAction.vue
+++ b/src/components/common/CallToAction.vue
@@ -12,7 +12,7 @@ interface Props {
 
 withDefaults(defineProps<Props>(), {
   title: 'Ready to grow your business?',
-  description: 'Book a free call and let's discuss how we can help you.',
+  description: "Book a free call and let's discuss how we can help you.",
   buttonText: 'Book a Free Call',
   variant: 'default'
 })


### PR DESCRIPTION
Correct a TypeScript syntax error in `CallToAction.vue` by escaping a curly apostrophe with double quotes.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 8952d805-afd5-4d20-b1f3-982e2bbb692b
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: c22377e5-e5a7-4d07-b57d-20d593674885
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/940fb0ac-9532-40a7-a45c-345696d3c5db/8952d805-afd5-4d20-b1f3-982e2bbb692b/MwEsXHy
Replit-Helium-Checkpoint-Created: true