### PR TITLE
Add a new gradient style for call to action components

### DIFF
--- a/src/components/common/CallToAction.vue
+++ b/src/components/common/CallToAction.vue
@@ -7,7 +7,7 @@ interface Props {
   buttonText?: string
   to?: string
   externalUrl?: string
-  variant?: 'default' | 'subtle'
+  variant?: 'default' | 'subtle' | 'gradient'
 }
 
 withDefaults(defineProps<Props>(), {
@@ -19,31 +19,31 @@ withDefaults(defineProps<Props>(), {
 </script>
 
 <template>
-  <section class="rounded-2xl px-6 py-12 sm:px-12 text-center" :class="variant === 'default'
-    ? 'bg-yellow-100 dark:bg-yellow-900/30'
-    : 'bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700'">
-    <h2 class="text-2xl sm:text-3xl font-extrabold text-gray-900 dark:text-white">
+  <section class="rounded-2xl px-6 py-12 sm:px-12 text-center" :class="{
+    'bg-yellow-100 dark:bg-yellow-900/30': variant === 'default',
+    'bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700': variant === 'subtle',
+    'bg-gradient-to-r from-primary to-blue-600': variant === 'gradient'
+  }">
+    <h2 class="text-2xl sm:text-3xl font-extrabold" :class="variant === 'gradient' ? 'text-white' : 'text-gray-900 dark:text-white'">
       {{ title }}
     </h2>
 
-    <p v-if="description" class="mt-4 max-w-2xl mx-auto text-gray-600 dark:text-gray-400">
+    <p v-if="description" class="mt-4 max-w-2xl mx-auto" :class="variant === 'gradient' ? 'text-white/90' : 'text-gray-600 dark:text-gray-400'">
       {{ description }}
     </p>
 
     <div class="mt-8 flex justify-center">
-      <RouterLink v-if="to" :to="to" class="inline-flex items-center justify-center
-               px-6 py-3 rounded-full
-               bg-primary hover:bg-primary-hover
-               text-white text-sm font-semibold
-               transition">
+      <RouterLink v-if="to" :to="to" :class="variant === 'gradient'
+        ? 'bg-white text-primary hover:bg-gray-100'
+        : 'bg-primary hover:bg-primary-hover text-white'"
+        class="inline-flex items-center justify-center px-6 py-3 rounded-full text-sm font-semibold transition">
         {{ buttonText }}
       </RouterLink>
 
-      <a v-else-if="externalUrl" :href="externalUrl" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center
-               px-6 py-3 rounded-full
-               bg-primary hover:bg-primary-hover
-               text-white text-sm font-semibold
-               transition">
+      <a v-else-if="externalUrl" :href="externalUrl" target="_blank" rel="noopener noreferrer" :class="variant === 'gradient'
+        ? 'bg-white text-primary hover:bg-gray-100'
+        : 'bg-primary hover:bg-primary-hover text-white'"
+        class="inline-flex items-center justify-center px-6 py-3 rounded-full text-sm font-semibold transition">
         {{ buttonText }}
       </a>
     </div>


### PR DESCRIPTION
Update CallToAction.vue to include a 'gradient' variant, modify template bindings for dynamic styling based on variant, and adjust text color for gradient background.

Replit-Commit-Author: Agent
Replit-Commit-Session-Id: 8952d805-afd5-4d20-b1f3-982e2bbb692b
Replit-Commit-Checkpoint-Type: full_checkpoint
Replit-Commit-Event-Id: f91a0d11-a7b9-4bfc-a524-48d4977603b6
Replit-Commit-Screenshot-Url: https://storage.googleapis.com/screenshot-production-us-central1/940fb0ac-9532-40a7-a45c-345696d3c5db/8952d805-afd5-4d20-b1f3-982e2bbb692b/aOCoTEP
Replit-Helium-Checkpoint-Created: true